### PR TITLE
Numeric Bucketing

### DIFF
--- a/AnalyticsKit.podspec
+++ b/AnalyticsKit.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/twobitlabs/AnalyticsKit.git", :tag => s.version.to_s }
 
   s.subspec 'Core' do |core|
-    core.source_files  = 'AnalyticsKit.{h,m}', 'AnalyticsKitEvent.{h,m}', 'AnalyticsKitDebugProvider.{h,m}'
+    core.source_files  = 'AnalyticsKit.{h,m}', 'AnalyticsKitEvent.{h,m}', 'AnalyticsKitDebugProvider.{h,m}', 'NSNumber+Buckets.{h,m}'
   end
 
   s.subspec 'Flurry' do |f|

--- a/NSNumber+Buckets.h
+++ b/NSNumber+Buckets.h
@@ -1,0 +1,25 @@
+//
+//  NSNumber+Buckets.h
+//  AnalyticsKit
+//
+//  Author: Jonathan Hersh (jon@her.sh)
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSNumber (Buckets)
+
+/*
+ * Many analytics services (*cough* Localytics *cough) do not bucket your values for you,
+ * so your reported numeric data can be awfully difficult to read.
+ * These bucketing functions will read in a number and output a bucketed range as a string.
+ * 
+ * Example: A value of 47, with bucket size 25, will return the string "25-49".
+ * A value of 10, with bucket size 15, will return the string "< 15".
+ */
+- (NSString *) bucketStringWithBucketSize:(NSUInteger)bucketSize;
+
+- (NSString *) bucketStringWithBucketSize:(NSUInteger)bucketSize 
+                               maxBuckets:(NSUInteger)maxBuckets;
+
+@end

--- a/NSNumber+Buckets.m
+++ b/NSNumber+Buckets.m
@@ -1,0 +1,35 @@
+//
+//  NSNumber+Buckets.m
+//  AnalyticsKit
+//
+//  Author: Jonathan Hersh (jon@her.sh)
+//
+
+#import "NSNumber+Buckets.h"
+
+@implementation NSNumber (Buckets)
+
+- (NSString *) bucketStringWithBucketSize:(NSUInteger)bucketSize {
+    return [self bucketStringWithBucketSize:bucketSize
+                                 maxBuckets:10];
+}
+
+- (NSString *) bucketStringWithBucketSize:(NSUInteger)bucketSize 
+                               maxBuckets:(NSUInteger)maxBuckets {
+						 
+    NSUInteger intVal = [self unsignedIntegerValue];
+
+    if( intVal < bucketSize )
+        return [NSString stringWithFormat:@"< %i", bucketSize];
+
+    NSUInteger multiple = intVal / bucketSize;
+
+    if( multiple >= maxBuckets )
+        return [NSString stringWithFormat:@">= %i", ( bucketSize * maxBuckets )];
+    
+    return [NSString stringWithFormat:@"%i - %i",
+		    ( multiple * bucketSize ),
+		    ( ( ( multiple + 1 ) * bucketSize ) - 1)];
+}
+
+@end


### PR DESCRIPTION
Thanks for a great project! I've added some bucketing functions I wrote to make working with Localytics a bit easier.

Many analytics services (_cough_ Localytics *cough) do not bucket your values for you, so your reported numeric data can be awfully difficult to read.

These bucketing functions will accept a number and output a bucketed range as a string.

Example: A value of 47, with bucket size 25, will return the string `"25-49"`.
A value of 10, with bucket size 15, will return the string `"< 15"`.

Currently implemented as a category on `AnalyticsKit`; open to other suggestions. Thanks!

Edit: Looks like the Localytics subspec has been omitted from the podspec. Intentional?
