### PR TITLE
Fixed typo in AnalyticsKitLocalyticsProvider, formerly "AnalyticsKitLoca...

### DIFF
--- a/Providers/Localytics/AnalyticsKitLocalyticsProvider.h
+++ b/Providers/Localytics/AnalyticsKitLocalyticsProvider.h
@@ -1,5 +1,5 @@
 //
-//  AnalyticsKitLocalyitcsProvider.h
+//  AnalyticsKitLocalyticsProvider.h
 //  AnalyticsKit
 //
 //  Created by Todd Huss on 10/17/11.
@@ -8,7 +8,7 @@
 
 #import "AnalyticsKit.h"
 
-@interface AnalyticsKitLocalyitcsProvider : NSObject<AnalyticsKitProvider>
+@interface AnalyticsKitLocalyticsProvider : NSObject<AnalyticsKitProvider>
 
 -(id<AnalyticsKitProvider>)initWithAPIKey:(NSString *)localyticsKey;
 

--- a/Providers/Localytics/AnalyticsKitLocalyticsProvider.m
+++ b/Providers/Localytics/AnalyticsKitLocalyticsProvider.m
@@ -1,15 +1,15 @@
 //
-//  AnalyticsKitLocalyitcsProvider.m
+//  AnalyticsKitLocalyticsProvider.m
 //  AnalyticsKit
 //
 //  Created by Todd Huss on 10/17/11.
 //  Copyright (c) 2011 Two Bit Labs. All rights reserved.
 //
 
-#import "AnalyticsKitLocalyitcsProvider.h"
+#import "AnalyticsKitLocalyticsProvider.h"
 #import "LocalyticsSession.h"
 
-@implementation AnalyticsKitLocalyitcsProvider
+@implementation AnalyticsKitLocalyticsProvider
 
 -(id<AnalyticsKitProvider>)initWithAPIKey:(NSString *)localyticsKey {
     self = [super init];


### PR DESCRIPTION
...lyitcsProvider"

Typo was causing Cocoapod usage of AnalyticsKit to break for Localytics
