### PR TITLE
Removed setDeviceIdentifier: as it is no longer in the SDK

### DIFF
--- a/Providers/TestFlight/AnalyticsKitTestFlightProvider.m
+++ b/Providers/TestFlight/AnalyticsKitTestFlightProvider.m
@@ -15,16 +15,7 @@
 -(id<AnalyticsKitProvider>)initWithAPIKey:(NSString *)testFlightKey {
     self = [super init];
     if (self) {
-        #ifdef DEBUG
-            #if (!TARGET_IPHONE_SIMULATOR)
-                // Since Apple no longer allows UDID, TestFlight recommends sending it only in DEBUG builds
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                NSString *deviceId = [[UIDevice currentDevice] uniqueIdentifier];
-                #pragma clang diagnostic pop
-                [TestFlight setDeviceIdentifier:deviceId];
-            #endif
-        #endif
+        // Removed setDeviceIdentifier:
         [TestFlight takeOff:testFlightKey];
     }
     return self;


### PR DESCRIPTION
Method removed from the TestFlight SDK in the 2.2.2 Version.

Solves issue #15
