### PR TITLE
Enable multiple GA instances with different IDs

### DIFF
--- a/AnalyticsKit/AnalyticsKitTests/AnalyticsKitTests.m
+++ b/AnalyticsKit/AnalyticsKitTests/AnalyticsKitTests.m
@@ -33,7 +33,9 @@
                            [AnalyticsKitCrashlyticsProvider new],
                            [AnalyticsKitDebugProvider new],
                            [[AnalyticsKitFlurryProvider alloc] initWithAPIKey:nil],
-                           [[AnalyticsKitGoogleAnalyticsProvider alloc] initWithTrackingID:nil],
+                           // testing multiple google tracker instances
+                           [[AnalyticsKitGoogleAnalyticsProvider alloc] initWithTrackingID:@"trackerId1"],
+                           [[AnalyticsKitGoogleAnalyticsProvider alloc] initWithTrackingID:@"trackerId2"],
                            // Localytics validates the key when you initialize it, so it can't be empty or fake
                            // This key is for the "AnalyticsKit iOS app"
                            [[AnalyticsKitLocalyticsProvider alloc] initWithAPIKey:@"03a5f224fe2408887ac32dd-68937c2c-fd90-11e4-b9d0-00eba64cb0ec"],

--- a/Providers/Google Analytics/AnalyticsKitGoogleAnalyticsProvider.m
+++ b/Providers/Google Analytics/AnalyticsKitGoogleAnalyticsProvider.m
@@ -24,7 +24,9 @@ static NSString* const kTime = @"time";
 static NSString* const kProperties = @"properties";
 
 
-@interface AnalyticsKitGoogleAnalyticsProvider ()
+@interface AnalyticsKitGoogleAnalyticsProvider () {
+    id _tracker;
+}
 
 -(id)valueFromDictionnary:(NSDictionary*)dictionnary forKey:(NSString*)key;
 @end
@@ -45,7 +47,7 @@ static NSString* const kProperties = @"properties";
 {
     self = [super init];
     if (self) {
-        [[GAI sharedInstance] trackerWithTrackingId:trackingID];
+        _tracker = [[GAI sharedInstance] trackerWithTrackingId:trackingID];
         timedEvents = [[NSMutableDictionary alloc] init];
         timingQueue = dispatch_queue_create("analyticsKit.goolgeAnalytics.provider", DISPATCH_QUEUE_SERIAL);
     }
@@ -58,14 +60,12 @@ static NSString* const kProperties = @"properties";
 -(void)applicationDidEnterBackground{}
 
 -(void)applicationWillTerminate{
-    id tracker = [[GAI sharedInstance] defaultTracker];
-    [tracker close];
+    [_tracker close];
 }
 
 -(void)uncaughtException:(NSException *)exception
 {
-    id tracker = [[GAI sharedInstance] defaultTracker];
-    [tracker send:[[GAIDictionaryBuilder
+    [_tracker send:[[GAIDictionaryBuilder
                     createExceptionWithDescription:[[exception userInfo] description]
                     withFatal:@(YES)] build]];
 }
@@ -74,17 +74,15 @@ static NSString* const kProperties = @"properties";
 //Logging events
 -(void)logScreen:(NSString *)screenName
 {
-    id tracker = [[GAI sharedInstance] defaultTracker];
-    [tracker set:kGAIScreenName
+    [_tracker set:kGAIScreenName
            value:screenName];
     
-    [tracker send:[[GAIDictionaryBuilder createAppView] build]];
+    [_tracker send:[[GAIDictionaryBuilder createAppView] build]];
 }
 
 -(void)logEvent:(NSString *)event
 {
-    id tracker = [[GAI sharedInstance] defaultTracker];
-    [tracker send:[[GAIDictionaryBuilder createEventWithCategory:nil
+    [_tracker send:[[GAIDictionaryBuilder createEventWithCategory:nil
                                                           action:event
                                                            label:nil
                                                            value:nil] build]];
@@ -92,8 +90,7 @@ static NSString* const kProperties = @"properties";
 
 -(void)logEvent:(NSString *)event withProperty:(NSString *)key andValue:(NSString *)value
 {
-    id tracker = [[GAI sharedInstance] defaultTracker];
-    [tracker send:[[GAIDictionaryBuilder createEventWithCategory:key
+    [_tracker send:[[GAIDictionaryBuilder createEventWithCategory:key
                                                       action:event
                                                        label:value
                                                        value:nil] build]];
@@ -105,8 +102,7 @@ static NSString* const kProperties = @"properties";
     NSString* label = [self valueFromDictionnary:dict forKey:kLabel];
     NSNumber* value = [self valueFromDictionnary:dict forKey:kValue];
     
-    id tracker = [[GAI sharedInstance] defaultTracker];
-    [tracker send:[[GAIDictionaryBuilder createEventWithCategory:category
+    [_tracker send:[[GAIDictionaryBuilder createEventWithCategory:category
                                                           action:event
                                                            label:label
                                                            value:value] build]];
@@ -166,8 +162,7 @@ static NSString* const kProperties = @"properties";
         [timedEvents removeObjectForKey:event];
     });
 
-    id tracker = [[GAI sharedInstance] defaultTracker];
-    [tracker send:[[GAIDictionaryBuilder createTimingWithCategory:category
+    [_tracker send:[[GAIDictionaryBuilder createTimingWithCategory:category
                                                          interval:@(time)
                                                              name:event
                                                             label:label] build]];
@@ -179,9 +174,8 @@ static NSString* const kProperties = @"properties";
 
 -(void)logError:(NSString *)name message:(NSString *)message exception:(NSException *)exception
 {
-    id tracker = [[GAI sharedInstance] defaultTracker];
     // isFatal = NO, presume here, Exeption is not fatal.
-    [tracker send:[[GAIDictionaryBuilder
+    [_tracker send:[[GAIDictionaryBuilder
                     createExceptionWithDescription:message
                     withFatal:@(NO)] build]];
 
@@ -189,9 +183,8 @@ static NSString* const kProperties = @"properties";
 
 -(void)logError:(NSString *)name message:(NSString *)message error:(NSError *)error
 {
-    id tracker = [[GAI sharedInstance] defaultTracker];
     // isFatal = NO, presume here, Exeption is not fatal.
-    [tracker send:[[GAIDictionaryBuilder
+    [_tracker send:[[GAIDictionaryBuilder
                     createExceptionWithDescription:message
                     withFatal:@(NO)] build]];
 }


### PR DESCRIPTION
This allows usage of multiple google analytics trackers inside and outside of analytics kit.