### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ If you would like to add support for a new provider or to update the code for an
 
 ## How to Use
 
-### Cocoapods
+### CocoaPods
 
-__***Please Note__ -- While we welcome contributions, Two Bit Labs does not officially support Cocoapods for AnalyticsKit. If you run into problems integrating AnalyticsKit using Cocoapods, please log a GitHub issue.
+__***Please Note__ -- While we welcome contributions, Two Bit Labs does not officially support CocoaPods for AnalyticsKit. If you run into problems integrating AnalyticsKit using CocoaPods, please log a GitHub issue.
 
-If your project uses Cocoapods, you can simply include `AnalyticsKit` for full provider support, or you can specify your provider using Cocoapods subspecs.
+If your project uses CocoaPods, you can simply include `AnalyticsKit` for full provider support, or you can specify your provider using CocoaPods subspecs.
 
 * AdjustIO - `pod 'AnalyticsKit/AdjustIO'`
 * Flurry - `pod 'AnalyticsKit/Flurry'`
@@ -45,7 +45,7 @@ If your project uses Cocoapods, you can simply include `AnalyticsKit` for full p
 * New Relic - `pod 'AnalyticsKit/NewRelic'`
 * TestFlight - `pod 'AnalyticsKit/TestFlight'`
 
-__***Please Note__ -- The Parse subspec has been removed, as it won't integrate correctly using Cocoapods.
+__***Please Note__ -- The Parse subspec has been removed, as it won't integrate correctly using CocoaPods.
 
 ### Installation
 1. Download the provider's SDK and add it to your project, or install via cocoapods.


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
